### PR TITLE
Accommodating alternatives to check profane words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .vscode/
+.idea/
 __pycache__/
 csvData/
 dist/
 logs/
+venv/
 .pytest_cache/
 *.zip
 PyProfane/main.py

--- a/PyProfane/constants.py
+++ b/PyProfane/constants.py
@@ -155,3 +155,12 @@ profaneWords = {
     'hell', 'anal', 'poop', 'arse', 'cock', 'balls', 'asswhore', 'fag',
     'bullshit'
 }
+
+profaneSubstitutes = {
+    '1': 'i',
+    '$': 's',
+    '@': 'a',
+    '3': 'e',
+    '0': 'o',
+    '5': 's'
+}

--- a/PyProfane/data/comments.txt
+++ b/PyProfane/data/comments.txt
@@ -6,3 +6,4 @@ fucking wanker
 hey, hope you do great!
 sluttyyyy whoreeee
 wear a dress
+$hit man, what a b1tch

--- a/PyProfane/functions.py
+++ b/PyProfane/functions.py
@@ -1,6 +1,6 @@
 from PyProfane.constants import censorSymbols, censorSymbolsLength, \
     letterMappings, lettersToRemove, profaneWordSoundex, \
-    profaneWordsSoundexValues, profaneWords
+    profaneWordsSoundexValues, profaneWords, profaneSubstitutes
 from typing import List
 import re
 import random
@@ -42,10 +42,22 @@ def soundex(term: str) -> str:
     return sound
 
 
+def replaceSubstitutes(sentence: str) -> str:
+    '''
+    Replace commonly used substitutes by their corresponding letters
+    '''
+
+    for char in profaneSubstitutes:
+        sentence = sentence.replace(char, profaneSubstitutes[char])
+    return sentence
+
+
 def censorWord(word: str) -> str:
     '''
     Censor word.
     '''
+    word = replaceSubstitutes(word)
+
     term = list(word)
     length = len(term)
     if length <= 4:
@@ -67,6 +79,7 @@ def censorSentences(comments: List[str]) -> List[str]:
     '''
 
     sentences = []
+    comments = [replaceSubstitutes(comment) for comment in comments]
 
     for i in comments:
         soundexComment = i
@@ -116,6 +129,8 @@ def isProfane(sentence: str) -> bool:
     '''
     Function that returns if a sentence is profane or not.
     '''
+
+    sentence = replaceSubstitutes(sentence)
 
     allWords = re.findall(r"[\w']+|[.,!?;]", sentence)
     for j in allWords:

--- a/PyProfane/functions.py
+++ b/PyProfane/functions.py
@@ -47,9 +47,27 @@ def replaceSubstitutes(sentence: str) -> str:
     Replace commonly used substitutes by their corresponding letters
     '''
 
+    subChars = ''
     for char in profaneSubstitutes:
-        sentence = sentence.replace(char, profaneSubstitutes[char])
-    return sentence
+        subChars += char
+    allWords = re.findall(r"[\w'{}]+|[\W]".format(subChars),
+                          sentence
+                          )
+    translatedSentence = ''
+    for word in allWords:
+        translatedWord = ''
+        for char in word:
+            if char in profaneSubstitutes:
+                translatedWord += profaneSubstitutes[char]
+            else:
+                translatedWord += char
+
+        if isProfane(translatedWord):
+            translatedSentence += translatedWord
+        else:
+            translatedSentence += word
+
+    return translatedSentence
 
 
 def censorWord(word: str) -> str:
@@ -129,8 +147,6 @@ def isProfane(sentence: str) -> bool:
     '''
     Function that returns if a sentence is profane or not.
     '''
-
-    sentence = replaceSubstitutes(sentence)
 
     allWords = re.findall(r"[\w']+|[.,!?;]", sentence)
     for j in allWords:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,20 +1,35 @@
-from PyProfane.functions import isProfane, censorWord, censorSentences
+from PyProfane.functions import soundex, isProfane, censorWord, \
+    censorSentences, replaceSubstitutes
 from PyProfane.constants import profaneWords
 import unittest
 
 
 class Testclass(unittest.TestCase):
+    def testSoundex(self):
+        word = "wank"
+
+        self.assertEqual(soundex(word), 'W520')
+
     def testIsProfane(self):
         sentence1 = "fucking wanker"
         sentence2 = "hey, hope you do great!"
+        sentence3 = "$h1t man, what a b1tch"
 
         self.assertTrue(isProfane(sentence1))
         self.assertFalse(isProfane(sentence2))
+        self.assertTrue(isProfane(sentence3))
+
+    def testReplaceSubstitutes(self):
+        word = "n1gg@"
+
+        self.assertEqual(replaceSubstitutes(word), 'nigga')
 
     def testCensorWord(self):
-        word = "fuckinggg"
+        word1 = "fuckinggg"
+        word2 = "n1gg@"
 
-        self.assertNotEqual(censorWord(word), word)
+        self.assertNotEqual(censorWord(word1), word1)
+        self.assertNotEqual(censorWord(word2), word2)
 
     def testCensorSentences(self):
         fileObj = open('PyProfane/data/comments.txt', 'r')

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -13,16 +13,16 @@ class Testclass(unittest.TestCase):
     def testIsProfane(self):
         sentence1 = "fucking wanker"
         sentence2 = "hey, hope you do great!"
-        sentence3 = "$h1t man, what a b1tch"
 
         self.assertTrue(isProfane(sentence1))
         self.assertFalse(isProfane(sentence2))
-        self.assertTrue(isProfane(sentence3))
 
     def testReplaceSubstitutes(self):
-        word = "n1gg@"
+        word1 = "n1gg@"
+        word2 = "10$"
 
-        self.assertEqual(replaceSubstitutes(word), 'nigga')
+        self.assertEqual(replaceSubstitutes(word1), 'nigga')
+        self.assertEqual(replaceSubstitutes(word2), '10$')
 
     def testCensorWord(self):
         word1 = "fuckinggg"


### PR DESCRIPTION
### Changes to solve #4 
- Added the `replaceSubstitutes` function in `functions.py` to replace characters commonly used to avoid profanity checkers by their corresponding letter :sparkles:
- Added a couple common substitutes in `constants.py` (more could be added)
- Added tests :white_check_mark:

**+ Linting:** Used `flake8` to lint all the code :rotating_light: